### PR TITLE
Update webhook_backend.py

### DIFF
--- a/awx/main/notifications/webhook_backend.py
+++ b/awx/main/notifications/webhook_backend.py
@@ -72,7 +72,7 @@ class WebhookBackend(AWXBaseEmailBackend, CustomNotificationBase):
                 "{}".format(m.recipients()[0]),
                 auth=auth,
                 data=json.dumps(m.body, ensure_ascii=False).encode('utf-8'),
-                headers=get_awx_http_client_headers(),
+                headers=dict(list(get_awx_http_client_headers().items()) + list((self.headers or {}).items())),
                 verify=(not self.disable_ssl_verification),
             )
             if r.status_code >= 400:


### PR DESCRIPTION

##### SUMMARY

The current request via webhook just uses default pre configured headers (with _Agent_/_ContentType_ keys) by ignoring at all customer provided headers (_self.headers_).
Thus the OAuth authentication via _Bearer_ cannot be implemented since custom headers are not sent to service so receiving **Unauthorized** response.

Solution is merging the default headers (_get_awx_http_client_headers_) with custom ones (self.headers or {}).
**Note**: custom headers will override default ones in case of key clash (so on keys  _Agent_/_ContentType_).


##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
AWX 19.2.0
```


##### ADDITIONAL INFORMATION
Takes also into account a situation of a null header provided
```
self.headers or {}
```


